### PR TITLE
edited label proc-block; ran `cargo fmt` on all proc-blocks

### DIFF
--- a/audio_float_conversion/src/lib.rs
+++ b/audio_float_conversion/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
-use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
+use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 
 // TODO: Add Generics
 
@@ -36,7 +36,9 @@ impl AudioFloatConversion {
 }
 
 impl Default for AudioFloatConversion {
-    fn default() -> Self { AudioFloatConversion::new() }
+    fn default() -> Self {
+        AudioFloatConversion::new()
+    }
 }
 
 impl Transform<Tensor<i16>> for AudioFloatConversion {

--- a/fft/src/lib.rs
+++ b/fft/src/lib.rs
@@ -14,9 +14,9 @@ extern crate pretty_assertions;
 pub type Fft = ShortTimeFourierTransform;
 
 use alloc::{sync::Arc, vec::Vec};
-use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
-use sonogram::SpecOptionsBuilder;
+use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use nalgebra::DMatrix;
+use sonogram::SpecOptionsBuilder;
 
 #[derive(Debug, Clone, PartialEq, ProcBlock)]
 pub struct ShortTimeFourierTransform {
@@ -107,7 +107,9 @@ impl ShortTimeFourierTransform {
 }
 
 impl Default for ShortTimeFourierTransform {
-    fn default() -> Self { ShortTimeFourierTransform::new() }
+    fn default() -> Self {
+        ShortTimeFourierTransform::new()
+    }
 }
 
 impl Transform<Tensor<i16>> for ShortTimeFourierTransform {

--- a/image-normalization/src/lib.rs
+++ b/image-normalization/src/lib.rs
@@ -4,8 +4,8 @@
 #[macro_use]
 extern crate alloc;
 
+use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use num_traits::{Bounded, ToPrimitive};
-use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
 
 /// A normalization routine which takes some tensor of integers and fits their
 /// values to the range `[0, 1]` as `f32`'s.

--- a/label/Cargo.toml
+++ b/label/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "label"
-version = "0.0.0"
+version = "0.8.0"
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-blocks = "^0.9.0"
+libm = {version = "0.2.1", default-features = false}
+hotg-rune-proc-blocks = "^0.9.2"

--- a/label/src/into_index_macro.rs
+++ b/label/src/into_index_macro.rs
@@ -1,0 +1,85 @@
+use core::convert::TryInto;
+use libm::floorf;
+
+pub trait IntoIndex: Sized {
+    fn try_into_index(self) -> usize;
+}
+
+macro_rules! float_into_index {
+    ($($float:ty),*$(,)?) => {$(
+        impl IntoIndex for $float {
+            fn try_into_index(self) -> usize {
+                // Integers are exactly representable at or below this value
+                const MAX_VALUE: $float = (1u64 << <$float>::MANTISSA_DIGITS) as $float;
+
+                assert!(!self.is_nan(),"The index can't be NAN");
+                assert!(!self.is_infinite(), "The index can't be infinite");
+                assert!(self >= 0.0, "The index must be a positive number");
+                assert!(self <= MAX_VALUE, "The index is larger than the largest number that can safely represent an integer");
+                assert_eq!(self - floorf(self), 0.0, "The index wasn't an integer");
+
+                (self as u32).try_into().expect("UNSUPPORTED: Can't be converted to usize. It only supports u8, u16, u32, u64, i32, i64 ( with positive numbers) f32 (with their fractional part zero E.g. 2.0, 4.0, etc)")
+            }
+        }
+    )*}
+}
+
+float_into_index!(f32);
+
+macro_rules! integer_into_index {
+    ($($int:ty),*$(,)?) => {$(
+        impl IntoIndex for $int {
+            fn try_into_index(self) -> usize {
+                self.try_into().ok().expect("UNSUPPORTED: Can't be converted to usize. It only supports u8, u16, u32, u64, i32, i64 ( with positive numbers) f32 (with their fractional part zero E.g. 2.0, 4.0, etc)")
+            }
+        }
+    )*}
+}
+
+integer_into_index!(
+    i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_f32_floats() {
+        assert_eq!(1, 1.0f32.try_into_index())
+    }
+
+    #[test]
+    fn test_u32_inetger() {
+        assert_eq!(1, 1u32.try_into_index())
+    }
+
+    #[test]
+    #[should_panic = "UNSUPPORTED: Can't be converted to usize. It only supports u8, u16, u32, u64, i32, i64 ( with positive numbers) f32 (with their fractional part zero E.g. 2.0, 4.0, etc)"]
+    fn test_negative_integer() {
+        (-1).try_into_index();
+    }
+
+    #[test]
+    #[should_panic = "The index can't be infinite"]
+    fn test_infinite() {
+        (1.0 / 0.0).try_into_index();
+    }
+
+    #[test]
+    #[should_panic = "The index must be a positive number"]
+    fn test_negative_float() {
+        (-3.0).try_into_index();
+    }
+    #[test]
+    #[should_panic = "The index wasn't an intege"]
+    fn test_float_with_fraction() {
+        (4.3).try_into_index();
+    }
+
+    #[test]
+    #[should_panic = "The index is larger than the largest number that can safely represent an integer"]
+    fn test_float_out_of_bound() {
+        (16_777_216_456_673_784.0).try_into_index();
+    }
+}

--- a/modulo/src/lib.rs
+++ b/modulo/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
+use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use num_traits::{FromPrimitive, ToPrimitive};
-use hotg_rune_proc_blocks::{Tensor, Transform, ProcBlock};
 
 pub fn modulo<T>(modulus: f32, values: &mut [T])
 where
@@ -19,11 +19,15 @@ pub struct Modulo {
 }
 
 impl Modulo {
-    pub fn new() -> Self { Modulo { modulus: 1.0 } }
+    pub fn new() -> Self {
+        Modulo { modulus: 1.0 }
+    }
 }
 
 impl Default for Modulo {
-    fn default() -> Self { Modulo::new() }
+    fn default() -> Self {
+        Modulo::new()
+    }
 }
 
 impl<'a, T> Transform<Tensor<T>> for Modulo

--- a/most_confident_indices/src/lib.rs
+++ b/most_confident_indices/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use core::{convert::TryInto, fmt::Debug};
 
 use alloc::vec::Vec;
-use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
+use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 
 /// A proc block which, when given a list of confidences, will return the
 /// indices of the top N most confident values.
@@ -18,7 +18,9 @@ pub struct MostConfidentIndices {
 }
 
 impl MostConfidentIndices {
-    pub fn new(count: usize) -> Self { MostConfidentIndices { count } }
+    pub fn new(count: usize) -> Self {
+        MostConfidentIndices { count }
+    }
 
     fn check_input_dimensions(&self, dimensions: &[usize]) {
         match simplify_dimensions(dimensions) {
@@ -37,7 +39,9 @@ impl MostConfidentIndices {
 }
 
 impl Default for MostConfidentIndices {
-    fn default() -> Self { MostConfidentIndices::new(1) }
+    fn default() -> Self {
+        MostConfidentIndices::new(1)
+    }
 }
 
 impl<T: PartialOrd + Copy> Transform<Tensor<T>> for MostConfidentIndices {

--- a/noise-filtering/src/lib.rs
+++ b/noise-filtering/src/lib.rs
@@ -8,10 +8,10 @@ mod macros;
 mod gain_control;
 mod noise_reduction;
 
-pub use noise_reduction::NoiseReduction;
 pub use gain_control::GainControl;
+pub use noise_reduction::NoiseReduction;
 
-use hotg_rune_proc_blocks::{ProcBlock, Transform, Tensor};
+use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 
 #[derive(Debug, Default, Clone, PartialEq, ProcBlock)]
 pub struct NoiseFiltering {

--- a/noise-filtering/src/noise_reduction.rs
+++ b/noise-filtering/src/noise_reduction.rs
@@ -56,7 +56,9 @@ impl NoiseReduction {
         min_signal_remaining: f32,
     );
 
-    pub fn noise_estimate(&self) -> &[u32] { &self.estimate }
+    pub fn noise_estimate(&self) -> &[u32] {
+        &self.estimate
+    }
 
     pub fn transform(&mut self, mut input: Tensor<u32>) -> Tensor<u32> {
         // make sure we have the right estimate buffer size and panic if we

--- a/normalize/src/lib.rs
+++ b/normalize/src/lib.rs
@@ -7,7 +7,7 @@ use core::{
     fmt::Debug,
     ops::{Div, Sub},
 };
-use hotg_rune_proc_blocks::{Transform, Tensor};
+use hotg_rune_proc_blocks::{Tensor, Transform};
 
 pub fn normalize<T>(input: &mut [T])
 where
@@ -70,7 +70,7 @@ where
             let min = if item < min { item } else { min };
             let max = if max < item { item } else { max };
             Some((min, max))
-        },
+        }
         None => Some((item, item)),
     })
 }


### PR DESCRIPTION
1. updated label proc-block to support `f32, u8, u16, .. u128`
2. Ran `cargo fmt` on all the proc-blocks.