### PR TITLE
All proc-blocks are #[no_std] again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
         run: aws s3 sync target/proc-blocks s3://assets.hotg.ai/proc-blocks
         if: github.ref == 'refs/heads/master'
       - name: Invalidate Cloudfront
-        run: aws cloudfront create-invalidation --distribution-id=E20FU757GIUYVT --paths="/proc-blocks/*"
+        run: aws cloudfront create-invalidation --distribution-id=${{ secrets.AWS_DISTRIBUTION_ID }} --paths="/proc-blocks/*"
         if: github.ref == 'refs/heads/master' && matrix.rust == 'stable'
 
   api-docs:

--- a/argmax/src/lib.rs
+++ b/argmax/src/lib.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::vec::Vec;
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 
 #[derive(Debug, Clone, PartialEq, ProcBlock)]

--- a/audio_float_conversion/src/lib.rs
+++ b/audio_float_conversion/src/lib.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(not(feature = "metadata"), no_std)]
+
+extern crate alloc;
+
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 
 #[derive(Debug, Clone, PartialEq, ProcBlock)]
@@ -96,6 +99,7 @@ pub mod metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn handle_empty() {

--- a/audio_float_conversion/src/lib.rs
+++ b/audio_float_conversion/src/lib.rs
@@ -1,6 +1,5 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
-
-// TODO: Add Generics
 
 #[derive(Debug, Clone, PartialEq, ProcBlock)]
 #[transform(inputs = [i16; _], outputs = [f32; _])]

--- a/binary_classification/src/lib.rs
+++ b/binary_classification/src/lib.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::vec::Vec;
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 
 /// A proc-block which takes a rank 1 `tensor` as input, return 1 if value

--- a/fft/src/lib.rs
+++ b/fft/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
 #[cfg(test)]
 #[macro_use]
 extern crate std;
@@ -5,14 +7,17 @@ extern crate std;
 #[macro_use]
 extern crate pretty_assertions;
 
+#[macro_use]
+extern crate alloc;
+
 /// A type alias for [`ShortTimeFourierTransform`] which uses the camel case
 /// version of this crate.
 pub type Fft = ShortTimeFourierTransform;
 
+use alloc::{sync::Arc, vec::Vec};
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use nalgebra::DMatrix;
 use sonogram::SpecOptionsBuilder;
-use std::{sync::Arc, vec::Vec};
 
 #[derive(Debug, Clone, PartialEq, ProcBlock)]
 pub struct ShortTimeFourierTransform {

--- a/fft/src/lib.rs
+++ b/fft/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(feature = "metadata"), no_std)]
 
 #[cfg(test)]
-#[macro_use]
 extern crate std;
 #[cfg(test)]
 #[macro_use]

--- a/image-normalization/src/lib.rs
+++ b/image-normalization/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use num_traits::{Bounded, ToPrimitive};
 

--- a/image-normalization/src/lib.rs
+++ b/image-normalization/src/lib.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(not(feature = "metadata"), no_std)]
+
+extern crate alloc;
+
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use num_traits::{Bounded, ToPrimitive};
 
@@ -113,6 +116,7 @@ pub mod metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn normalizing_with_default_distribution_is_noop() {

--- a/label/src/into_index_macro.rs
+++ b/label/src/into_index_macro.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use core::convert::TryInto;
 use libm::floorf;
 
 pub trait IntoIndex: Sized {
@@ -45,37 +45,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_f32_floats() {
-        assert_eq!(1, 1.0f32.try_into_index())
-    }
+    fn test_f32_floats() { assert_eq!(1, 1.0f32.try_into_index()) }
 
     #[test]
-    fn test_u32_inetger() {
-        assert_eq!(1, 1u32.try_into_index())
-    }
+    fn test_u32_inetger() { assert_eq!(1, 1u32.try_into_index()) }
 
     #[test]
     #[should_panic = "UNSUPPORTED: Can't be converted to usize. It only supports u8, u16, u32, u64, i32, i64 ( with positive numbers) f32 (with their fractional part zero E.g. 2.0, 4.0, etc)"]
-    fn test_negative_integer() {
-        (-1).try_into_index();
-    }
+    fn test_negative_integer() { (-1).try_into_index(); }
 
     #[test]
     #[should_panic = "The index can't be infinite"]
-    fn test_infinite() {
-        (1.0 / 0.0).try_into_index();
-    }
+    fn test_infinite() { (1.0 / 0.0).try_into_index(); }
 
     #[test]
     #[should_panic = "The index must be a positive number"]
-    fn test_negative_float() {
-        (-3.0).try_into_index();
-    }
+    fn test_negative_float() { (-3.0).try_into_index(); }
     #[test]
     #[should_panic = "The index wasn't an intege"]
-    fn test_float_with_fraction() {
-        (4.3).try_into_index();
-    }
+    fn test_float_with_fraction() { (4.3).try_into_index(); }
 
     #[test]
     #[should_panic = "The index is larger than the largest number that can safely represent an integer"]

--- a/label/src/lib.rs
+++ b/label/src/lib.rs
@@ -164,6 +164,7 @@ pub mod metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn get_the_correct_labels() {

--- a/label/src/lib.rs
+++ b/label/src/lib.rs
@@ -1,9 +1,18 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+extern crate alloc;
+
 pub mod into_index_macro;
 pub use into_index_macro::IntoIndex;
 
+use alloc::{
+    borrow::{Cow, ToOwned},
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{fmt::Debug, ops::Range};
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use line_span::LineSpans;
-use std::{borrow::Cow, fmt::Debug, ops::Range};
 
 /// A proc block which, when given a set of indices, will return their
 /// associated labels.

--- a/modulo/src/lib.rs
+++ b/modulo/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use num_traits::{FromPrimitive, ToPrimitive};
 

--- a/most_confident_indices/src/lib.rs
+++ b/most_confident_indices/src/lib.rs
@@ -146,6 +146,7 @@ pub mod metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     #[should_panic]

--- a/most_confident_indices/src/lib.rs
+++ b/most_confident_indices/src/lib.rs
@@ -1,5 +1,10 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::{convert::TryInto, fmt::Debug};
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
-use std::{convert::TryInto, fmt::Debug};
 
 /// A proc block which, when given a list of confidences, will return the
 /// indices of the top N most confident values.

--- a/noise-filtering/src/gain_control.rs
+++ b/noise-filtering/src/gain_control.rs
@@ -3,6 +3,7 @@
 //! [tf]: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/microfrontend/lib/pcan_gain_control.c
 
 use hotg_rune_proc_blocks::Tensor;
+use alloc::vec::Vec;
 
 pub const WIDE_DYNAMIC_FUNCTION_BITS: usize = 32;
 pub const WIDE_DYNAMIC_FUNCTION_LUT_SIZE: usize =

--- a/noise-filtering/src/lib.rs
+++ b/noise-filtering/src/lib.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
 mod gain_control;
 mod noise_reduction;
 

--- a/noise-filtering/src/noise_reduction.rs
+++ b/noise-filtering/src/noise_reduction.rs
@@ -2,8 +2,9 @@
 //!
 //! [tf]: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/microfrontend/lib/noise_reduction.c
 
+use alloc::vec::Vec;
+use core::str::FromStr;
 use hotg_rune_proc_blocks::Tensor;
-use std::str::FromStr;
 
 const NOISE_REDUCTION_BITS: usize = 14;
 

--- a/noise-filtering/src/noise_reduction.rs
+++ b/noise-filtering/src/noise_reduction.rs
@@ -124,7 +124,7 @@ impl FromStr for ScaledU16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     /// https://github.com/tensorflow/tensorflow/blob/5dcfc51118817f27fad5246812d83e5dccdc5f72/tensorflow/lite/experimental/microfrontend/lib/noise_reduction_test.cc#L41-L59
     #[test]

--- a/normalize/src/lib.rs
+++ b/normalize/src/lib.rs
@@ -1,5 +1,6 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
 use hotg_rune_proc_blocks::{Tensor, Transform};
-use std::{
+use core::{
     fmt::Debug,
     ops::{Div, Sub},
 };

--- a/object_filter/src/lib.rs
+++ b/object_filter/src/lib.rs
@@ -1,6 +1,12 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::cmp::Ordering;
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use libm::fabsf;
-use std::cmp::Ordering;
 
 /// A proc-block which takes 3-d tensor `[1, num_detection, detection_box(x, y,
 /// w, h) + confidence_scores + total_detection_classes]` and filter the

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -106,6 +106,7 @@ pub mod metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_for_number_in_lines() {

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -1,5 +1,10 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+extern crate alloc;
+
+use alloc::borrow::Cow;
+use core::{fmt::Debug, marker::PhantomData, str::FromStr};
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
-use std::{borrow::Cow, fmt::Debug, marker::PhantomData, str::FromStr};
 
 /// A proc block which can parse a string to numbers.
 #[derive(Debug, Clone, PartialEq, ProcBlock)]

--- a/segment_output/src/lib.rs
+++ b/segment_output/src/lib.rs
@@ -1,5 +1,9 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+#[macro_use]
+extern crate alloc;
+
+use alloc::{collections::btree_set::BTreeSet, sync::Arc, vec::Vec};
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
-use std::{collections::btree_set::BTreeSet, sync::Arc, vec::Vec};
 
 /// A proc-block which takes a rank 4 `tensor` as input, whose dimension is of
 /// this form `[1, x, y, z]`.

--- a/softmax/src/lib.rs
+++ b/softmax/src/lib.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(not(feature = "metadata"), no_std)]
+
+extern crate alloc;
+
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use libm::expf;
 
@@ -65,6 +68,7 @@ pub mod metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_softmax() {

--- a/softmax/src/lib.rs
+++ b/softmax/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
 use libm::expf;
 

--- a/text_extractor/src/lib.rs
+++ b/text_extractor/src/lib.rs
@@ -1,5 +1,10 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::{borrow::Cow, string::String, vec::Vec};
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
-use std::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq, ProcBlock)]
 pub struct TextExtractor {}

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
 pub mod tokenizer;
 pub mod vocab;
 
@@ -10,8 +15,12 @@ use crate::{
     },
     vocab::{BertVocab, Vocab},
 };
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::str::FromStr;
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
-use std::str::FromStr;
 
 #[derive(ProcBlock)]
 pub struct Tokenizers {

--- a/tokenizers/src/tokenizer/base_tokenizer.rs
+++ b/tokenizers/src/tokenizer/base_tokenizer.rs
@@ -20,6 +20,11 @@ use crate::{
     },
     vocab::Vocab,
 };
+use alloc::{
+    borrow::ToOwned,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 /// # Truncation strategy variants
 /// Indicates if and how sequence pairs exceeding a given length should be

--- a/tokenizers/src/tokenizer/bert_tokenizer.rs
+++ b/tokenizers/src/tokenizer/bert_tokenizer.rs
@@ -23,6 +23,7 @@ use crate::{
     },
     vocab::{BertVocab, Vocab},
 };
+use alloc::vec::Vec;
 
 /// # BERT tokenizer
 /// BERT tokenizer performing:

--- a/tokenizers/src/tokenizer/constants.rs
+++ b/tokenizers/src/tokenizer/constants.rs
@@ -9,7 +9,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 use lazy_static::lazy_static;
 

--- a/tokenizers/src/tokenizer/tokenization_utils.rs
+++ b/tokenizers/src/tokenizer/tokenization_utils.rs
@@ -23,8 +23,9 @@ use crate::{
     vocab::{BertVocab, Vocab},
     Mask, Offset, OffsetSize, Token, TokenRef,
 };
+use alloc::{borrow::ToOwned, vec::Vec, string::String};
 use anyhow::Result;
-use std::{borrow::BorrowMut, char, char::REPLACEMENT_CHARACTER, cmp::min};
+use core::{borrow::BorrowMut, char, char::REPLACEMENT_CHARACTER, cmp::min};
 use unicode_normalization::char::decompose_canonical;
 
 /// Cleans text by removing control characters and normalizing whitespace

--- a/tokenizers/src/vocab/base_vocab.rs
+++ b/tokenizers/src/vocab/base_vocab.rs
@@ -9,8 +9,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+};
 use anyhow::Result;
-use std::{collections::BTreeMap, hash::Hash, string::String};
+use core::hash::Hash;
 
 pub(crate) fn swap_key_values<
     T: Clone,

--- a/tokenizers/src/vocab/bert_vocab.rs
+++ b/tokenizers/src/vocab/bert_vocab.rs
@@ -12,8 +12,12 @@
 // limitations under the License.
 
 use crate::vocab::base_vocab::{swap_key_values, Vocab};
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+};
 use anyhow::Result;
-use std::{collections::BTreeMap, str::FromStr, string::String};
+use core::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub enum TokenError {

--- a/utf8_decode/src/lib.rs
+++ b/utf8_decode/src/lib.rs
@@ -1,5 +1,9 @@
+#![cfg_attr(not(feature = "metadata"), no_std)]
+#[macro_use]
+extern crate alloc;
+
+use alloc::{borrow::Cow, string::ToString};
 use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
-use std::borrow::Cow;
 
 /// A proc block which can convert u8 bytes to utf8
 #[derive(Debug, Default, Clone, PartialEq, ProcBlock)]

--- a/utf8_decode/src/lib.rs
+++ b/utf8_decode/src/lib.rs
@@ -76,6 +76,7 @@ pub mod metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{vec, vec::Vec};
 
     #[test]
     fn test_for_utf8_decoding() {


### PR DESCRIPTION
As part of #19 I found the generated WIT code would try to use parts of `std`, however Rune currently requires proc-blocks to be `#[no_std]` so the Rune internal crates can provide things like OOM and panic handling. My solution was to remove the `#[no_std]` annotation and see if everything still worked.

Everything seemed to be fine in CI, but when @Mohit0928 was writing a new Rune he accidentally forgot to pin the proc-block version to a specific tag, meaning it would pull from `master`.

Compiling the Rune then failed with the following:

```
 Compiling blazeface v0.0.0 (/Users/mohit/Library/Caches/runes/blazeface)
error: duplicate lang item in crate `std` (which `image_normalization` depends on): `panic_impl`.
  |
  = note: the lang item is first defined in crate `hotg_runicos_base_wasm` (which `blazeface` depends on)
  = note: first definition in `hotg_runicos_base_wasm` loaded from /Users/mohit/Library/Caches/runes/blazeface/target/wasm32-unknown-unknown/release/deps/libhotg_runicos_base_wasm-cac12e73d7a0948e.rlib
  = note: second definition in `std` loaded from /Users/mohit/.rustup/toolchains/nightly-2021-10-15-aarch64-apple-darwin/lib/rustlib/wasm32-unknown-unknown/lib/libstd-ecfc68b7dd3a7740.rlib

error: duplicate lang item in crate `std` (which `image_normalization` depends on): `oom`.
  |
  = note: the lang item is first defined in crate `hotg_runicos_base_wasm` (which `blazeface` depends on)
  = note: first definition in `hotg_runicos_base_wasm` loaded from /Users/mohit/Library/Caches/runes/blazeface/target/wasm32-unknown-unknown/release/deps/libhotg_runicos_base_wasm-cac12e73d7a0948e.rlib
  = note: second definition in `std` loaded from /Users/mohit/.rustup/toolchains/nightly-2021-10-15-aarch64-apple-darwin/lib/rustlib/wasm32-unknown-unknown/lib/libstd-ecfc68b7dd3a7740.rlib

error: could not compile `blazeface` due to 2 previous errors
Error: Compilation failed with exit code 101 
```

TL;DR: Both `std` (pulled in by the `image_normalization` crate because we'd removed `#[no_std]`) and `hotg_runicos_base_wasm` were trying to implement OOM and panic handlers, resulting in duplicates.

This PR re-introduces the `#[no_std]` attribute to all proc-blocks, with the attribute only being included when the `metadata` feature flag is disabled.