### PR TITLE
Remove the "cdylib" crate-type from all proc-blocks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,13 @@ jobs:
             ~/.cargo
             target/
             Cargo.lock
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.rust }}
       - name: Setup Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-          target: wasm32-unknown-unknown
       - run: ls -la */*
       - name: Type Checking
         uses: actions-rs/cargo@v1
@@ -51,11 +50,39 @@ jobs:
         with:
           command: test
           args: --all --verbose
+
+  compile-to-wasm:
+    name: Compile to WebAssembly
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/cache@v1
+        with:
+          path: |
+            ~/.cargo
+            target/
+            Cargo.lock
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.rust }}
+      - name: Setup Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          target: wasm32-unknown-unknown
       - name: Compile to WebAssembly
         uses: actions-rs/cargo@v1
         with:
           command: xtask
           args: dist --out-dir target/proc-blocks
+        env:
+          RUST_LOG: xtask=debug
       - name: Save Compiled proc-blocks
         uses: actions/upload-artifact@v2
         with:
@@ -74,7 +101,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
       - name: Invalidate Cloudfront
         run: aws cloudfront create-invalidation --distribution-id=${{ secrets.AWS_DISTRIBUTION_ID }} --paths="/proc-blocks/*"
-        if: github.ref == 'refs/heads/master' && matrix.rust == 'stable'
+        if: github.ref == 'refs/heads/master'
 
   api-docs:
     name: Publish API Docs to GitHub Pages

--- a/argmax/Cargo.toml
+++ b/argmax/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/hotg-ai/proc-blocks"
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/audio_float_conversion/Cargo.toml
+++ b/audio_float_conversion/Cargo.toml
@@ -14,9 +14,6 @@ wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", op
 [dev-dependencies]
 pretty_assertions = "0.7.2"
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/binary_classification/Cargo.toml
+++ b/binary_classification/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/hotg-ai/proc-blocks"
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/fft/Cargo.toml
+++ b/fft/Cargo.toml
@@ -22,9 +22,6 @@ wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", op
 [dev-dependencies]
 pretty_assertions = "0.7.2"
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/image-normalization/Cargo.toml
+++ b/image-normalization/Cargo.toml
@@ -12,9 +12,6 @@ num-traits = { version = "0.2.14", default-features = false }
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/label/Cargo.toml
+++ b/label/Cargo.toml
@@ -13,9 +13,6 @@ hotg-rune-proc-blocks = "^0.11.0"
 line-span = "0.1.3"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/modulo/Cargo.toml
+++ b/modulo/Cargo.toml
@@ -13,9 +13,6 @@ num-traits = { version = "0.2.14", default-features = false }
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/most_confident_indices/Cargo.toml
+++ b/most_confident_indices/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/hotg-ai/proc-blocks"
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/noise-filtering/Cargo.toml
+++ b/noise-filtering/Cargo.toml
@@ -13,9 +13,6 @@ libm = "0.2.1"
 paste = "1.0.5"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/normalize/Cargo.toml
+++ b/normalize/Cargo.toml
@@ -12,9 +12,6 @@ repository = "https://github.com/hotg-ai/proc-blocks"
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/object_filter/Cargo.toml
+++ b/object_filter/Cargo.toml
@@ -12,9 +12,6 @@ hotg-rune-proc-blocks = "^0.11.0"
 libm = {version = "0.2.1", default-features = false}
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/parse/Cargo.toml
+++ b/parse/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/hotg-ai/proc-blocks"
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/segment_output/Cargo.toml
+++ b/segment_output/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/hotg-ai/proc-blocks"
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/softmax/Cargo.toml
+++ b/softmax/Cargo.toml
@@ -12,9 +12,6 @@ hotg-rune-proc-blocks = "^0.11.0"
 libm = {version = "0.2.1", default-features = false}
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/text_extractor/Cargo.toml
+++ b/text_extractor/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/hotg-ai/proc-blocks"
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -14,9 +14,6 @@ anyhow = { version = "1.0", default-features = false }
 unicode-normalization = {version = "0.1.19", default-features =false}
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/utf8_decode/Cargo.toml
+++ b/utf8_decode/Cargo.toml
@@ -11,9 +11,6 @@ repository = "https://github.com/hotg-ai/proc-blocks"
 hotg-rune-proc-blocks = "^0.11.0"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [features]
 default = []
 metadata = ["wit-bindgen-rust"]

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -70,48 +70,43 @@ impl ProcBlocks {
         let cargo =
             std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
 
-        let mut cmd = Command::new(cargo);
-        cmd.arg("build")
-            .arg("--manifest-path")
-            .arg(&self.workspace_root)
-            .arg("--workspace")
-            .arg("--target=wasm32-unknown-unknown")
-            .arg("--exclude=xtask")
-            .arg("--features=metadata");
+        let mut libs = Vec::new();
 
-        match mode {
-            CompilationMode::Release => {
-                cmd.arg("--release");
-            },
-            CompilationMode::Debug => {},
+        for package in &self.packages {
+            let mut cmd = Command::new(&cargo);
+            cmd.arg("rustc")
+                .arg("--manifest-path")
+                .arg(&package.manifest_path)
+                .arg("--lib")
+                .arg("--target=wasm32-unknown-unknown")
+                .arg("--features=metadata")
+                .arg("-Zunstable-options")
+                .arg("--crate-type=cdylib");
+
+            match mode {
+                CompilationMode::Release => {
+                    cmd.arg("--release");
+                },
+                CompilationMode::Debug => {},
+            }
+
+            tracing::debug!(command = ?cmd, "Running cargo build");
+
+            let status = cmd.status().with_context(|| {
+                format!(
+                    "Unable to start \"{}\"",
+                    cmd.get_program().to_string_lossy()
+                )
+            })?;
+
+            tracing::debug!(exit_code = ?status.code(), "Cargo build completed");
+
+            if !status.success() {
+                anyhow::bail!("Compilation failed");
+            }
+
+            libs.push(&package.name);
         }
-
-        tracing::debug!(command = ?cmd, "Running cargo build");
-
-        let status = cmd.status().with_context(|| {
-            format!(
-                "Unable to start \"{}\"",
-                cmd.get_program().to_string_lossy()
-            )
-        })?;
-
-        tracing::debug!(exit_code = ?status.code(), "Cargo build completed");
-
-        if !status.success() {
-            anyhow::bail!("Compilation failed");
-        }
-
-        let libs: Vec<_> = self
-            .packages
-            .iter()
-            .filter(|pkg| pkg.features.contains_key("metadata"))
-            .filter_map(|pkg| {
-                pkg.targets
-                    .iter()
-                    .find(|t| t.kind.iter().any(|k| k == "cdylib"))
-                    .map(|t| &t.name)
-            })
-            .collect();
 
         tracing::debug!(?libs);
 

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -46,13 +46,11 @@ pub fn discover_proc_block_manifests(
     Ok(ProcBlocks {
         packages,
         target_dir: metadata.target_directory.into_std_path_buf(),
-        workspace_root: workspace_root.to_path_buf(),
     })
 }
 
 #[derive(Debug)]
 pub struct ProcBlocks {
-    workspace_root: PathBuf,
     packages: Vec<Package>,
     target_dir: PathBuf,
 }


### PR DESCRIPTION
As part of #19 we added `crate-type = ["cdylib", "rlib"]` to the `[lib]` section of each proc-block's `Cargo.toml` file, letting us compile the crate directly to a `*.wasm` file that can be loaded at runtime.

This works well when you build a proc-block normally (e.g. `cd normalize && cargo build`) or when generating a `*.wasm` file for the purpose of extracting metadata (`cargo build --target=wasm32-unknown-unknown --features=metadata`). However, when the crate is used as a dependency without the `metadata` feature (i.e. as part of `rune build`), we try to generate the `cdylib` and fail because it expects certain language items.

```
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait

error: `#[alloc_error_handler]` function required, but not found
note: Use `#![feature(default_alloc_error_handler)]` for a default error handler

error: `#[panic_handler]` function required, but not found
```

This PR removes the `crate-type` declarations and modifies `cargo xtask dist` to build each crate using `cargo rustc --crate-type=cdylib`. It should be good to merge, I'm just waiting for https://github.com/rust-lang/cargo/pull/10388 (fixed 14 hours ago) to hit nightly so we get the fix for https://github.com/rust-lang/cargo/issues/10356.

This also moves the `cargo xtask dist` step in CI to its own job because the `--crate-type` argument requires nightly Rust and the normal tests are compiled/run on the host while `cargo xtask dist` cross-compiles to WebAssembly.