### PR TITLE
Update the wit-bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,3 @@ members = [
     "object_filter",
     "xtask"
 ]
-
-
-[patch."https://github.com/bytecodealliance/wit-bindgen" ]
-wit-bindgen-rust = { git = "https://github.com/hotg-ai/wit-bindgen", branch = "troubleshoot-bad-paths" }
-wit-bindgen-wasmtime = { git = "https://github.com/hotg-ai/wit-bindgen", branch = "troubleshoot-bad-paths" }

--- a/argmax/src/lib.rs
+++ b/argmax/src/lib.rs
@@ -34,12 +34,8 @@ impl Transform<Tensor<f32>> for Argmax {
 
 #[cfg(feature = "metadata")]
 pub mod metadata {
-    wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
-    );
-    wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
-    );
+    wit_bindgen_rust::import!("../wit-files/rune/runtime-v1.wit");
+    wit_bindgen_rust::export!("../wit-files/rune/rune-v1.wit");
 
     struct RuneV1;
 

--- a/audio_float_conversion/src/lib.rs
+++ b/audio_float_conversion/src/lib.rs
@@ -48,10 +48,10 @@ impl Transform<Tensor<i16>> for AudioFloatConversion {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/binary_classification/src/lib.rs
+++ b/binary_classification/src/lib.rs
@@ -38,12 +38,8 @@ impl Transform<Tensor<f32>> for BinaryClassification {
 
 #[cfg(feature = "metadata")]
 pub mod metadata {
-    wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
-    );
-    wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
-    );
+    wit_bindgen_rust::import!("../wit-files/rune/runtime-v1.wit");
+    wit_bindgen_rust::export!("../wit-files/rune/rune-v1.wit");
 
     struct RuneV1;
 

--- a/fft/src/lib.rs
+++ b/fft/src/lib.rs
@@ -123,10 +123,10 @@ impl Transform<Tensor<i16>> for ShortTimeFourierTransform {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/image-normalization/src/lib.rs
+++ b/image-normalization/src/lib.rs
@@ -57,10 +57,10 @@ where
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/label/src/lib.rs
+++ b/label/src/lib.rs
@@ -103,10 +103,10 @@ impl core::str::FromStr for Lines {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/modulo/src/lib.rs
+++ b/modulo/src/lib.rs
@@ -44,10 +44,10 @@ where
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/most_confident_indices/src/lib.rs
+++ b/most_confident_indices/src/lib.rs
@@ -78,10 +78,10 @@ fn simplify_dimensions(mut dimensions: &[usize]) -> &[usize] {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/noise-filtering/src/lib.rs
+++ b/noise-filtering/src/lib.rs
@@ -113,12 +113,8 @@ impl Default for NoiseFiltering {
 
 #[cfg(feature = "metadata")]
 pub mod metadata {
-    wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
-    );
-    wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
-    );
+    wit_bindgen_rust::import!("../wit-files/rune/runtime-v1.wit");
+    wit_bindgen_rust::export!("../wit-files/rune/rune-v1.wit");
 
     struct RuneV1;
 

--- a/normalize/src/lib.rs
+++ b/normalize/src/lib.rs
@@ -72,10 +72,10 @@ where
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/object_filter/src/lib.rs
+++ b/object_filter/src/lib.rs
@@ -131,10 +131,10 @@ fn find_duplicate(objects: &[Object]) -> Option<(usize, usize)> {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/parse/src/lib.rs
+++ b/parse/src/lib.rs
@@ -66,10 +66,10 @@ where
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/segment_output/src/lib.rs
+++ b/segment_output/src/lib.rs
@@ -76,12 +76,8 @@ impl Transform<Tensor<f32>> for SegmentOutput {
 
 #[cfg(feature = "metadata")]
 pub mod metadata {
-    wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
-    );
-    wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
-    );
+    wit_bindgen_rust::import!("../wit-files/rune/runtime-v1.wit");
+    wit_bindgen_rust::export!("../wit-files/rune/rune-v1.wit");
 
     struct RuneV1;
 

--- a/softmax/src/lib.rs
+++ b/softmax/src/lib.rs
@@ -30,10 +30,10 @@ impl Transform<Tensor<f32>> for Softmax {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/text_extractor/src/lib.rs
+++ b/text_extractor/src/lib.rs
@@ -64,10 +64,10 @@ impl Transform<(Tensor<u8>, Tensor<u32>, Tensor<u32>)> for TextExtractor {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -115,10 +115,10 @@ impl Transform<(Tensor<u8>, Tensor<u8>)> for Tokenizers {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/utf8_decode/src/lib.rs
+++ b/utf8_decode/src/lib.rs
@@ -32,10 +32,10 @@ impl Transform<Tensor<u8>> for Utf8Decode {
 #[cfg(feature = "metadata")]
 pub mod metadata {
     wit_bindgen_rust::import!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/runtime-v1.wit"
+        "../wit-files/rune/runtime-v1.wit"
     );
     wit_bindgen_rust::export!(
-        "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+        "../wit-files/rune/rune-v1.wit"
     );
 
     struct RuneV1;

--- a/xtask/src/metadata.rs
+++ b/xtask/src/metadata.rs
@@ -7,11 +7,9 @@ use std::{
 };
 use wasmtime::{Engine, Linker, Module, Store};
 
-wit_bindgen_wasmtime::export!(
-    "${CARGO_MANIFEST_DIR}/../wit-files/rune/runtime-v1.wit"
-);
+wit_bindgen_wasmtime::export!("../wit-files/rune/runtime-v1.wit");
 wit_bindgen_wasmtime::import!(
-    "$CARGO_MANIFEST_DIR/../wit-files/rune/rune-v1.wit"
+    "../wit-files/rune/rune-v1.wit"
 );
 
 pub fn generate_manifest(


### PR DESCRIPTION
Now that bytecodealliance/wit-bindgen#167 has been merged we can use it instead of our temporary fork.