### PR TITLE
Introduce "cargo xtask" commands for interacting with a compiled proc-block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,7 @@ members = [
     "support",
 ]
 
-# Temporary override while waiting for a fix to be merged upstream.
-# See https://github.com/bytecodealliance/wit-bindgen/pull/184
-[patch.'https://github.com/bytecodealliance/wit-bindgen']
-wit-bindgen-rust = { git = "https://github.com/hotg-ai/wit-bindgen", branch = "variant-should-be-clone" }
-wit-bindgen-wasmtime = { git = "https://github.com/hotg-ai/wit-bindgen", branch = "variant-should-be-clone" }
+# Uncomment these lines if you need to override wit-bindgen with hotg's fork.
+#[patch.'https://github.com/bytecodealliance/wit-bindgen']
+#wit-bindgen-rust = { git = "https://github.com/hotg-ai/wit-bindgen", branch = "variant-should-be-clone" }
+#wit-bindgen-wasmtime = { git = "https://github.com/hotg-ai/wit-bindgen", branch = "variant-should-be-clone" }

--- a/xtask/src/bin/xtask.rs
+++ b/xtask/src/bin/xtask.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use anyhow::{Context, Error};
 use structopt::StructOpt;
@@ -18,18 +18,20 @@ fn main() -> Result<(), Error> {
     match cmd {
         Command::Dist(d) => d.execute(),
         Command::Metadata(m) => m.execute(),
+        Command::Graph(g) => g.execute(),
     }
 }
 
 #[derive(Debug, StructOpt)]
-pub enum Command {
+enum Command {
     /// Compile all proc-blocks to WebAssembly and generate a manifest file.
     Dist(Dist),
     Metadata(Metadata),
+    Graph(Graph),
 }
 
 #[derive(Debug, StructOpt)]
-pub struct Dist {
+struct Dist {
     /// The top-level `Cargo.toml` file.
     #[structopt(long, default_value = "./Cargo.toml")]
     workspace_root: PathBuf,
@@ -82,7 +84,7 @@ impl Dist {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct Metadata {
+struct Metadata {
     /// The WebAssembly module to load.
     #[structopt(parse(from_os_str))]
     rune: PathBuf,
@@ -107,5 +109,59 @@ impl Metadata {
         println!("{}", json);
 
         Ok(())
+    }
+}
+
+#[derive(Debug, StructOpt)]
+struct Graph {
+    /// The WebAssembly module to load.
+    #[structopt(parse(from_os_str))]
+    rune: PathBuf,
+    #[structopt(parse(try_from_str))]
+    args: Vec<Argument>,
+}
+
+impl Graph {
+    fn execute(self) -> Result<(), Error> {
+        let wasm = std::fs::read(&self.rune).with_context(|| {
+            format!("Unable to read \"{}\"", self.rune.display())
+        })?;
+
+        let mut runtime = Runtime::load(&wasm)
+            .context("Unable to load the WebAssembly module")?;
+
+        let arguments: HashMap<_, _> =
+            self.args.into_iter().map(|a| (a.key, a.value)).collect();
+
+        let info = runtime
+            .graph(arguments)
+            .context("Unable to infer the input and output tensors")?;
+
+        let json = serde_json::to_string_pretty(&info)
+            .context("Unable to serialize the metadata to JSON")?;
+
+        println!("{}", json);
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct Argument {
+    key: String,
+    value: String,
+}
+
+impl FromStr for Argument {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (key, value) =
+            s.split_once("=").context("Expected a `key=value` pair")?;
+
+        Ok(Argument {
+            key: key.to_string(),
+            value: value.to_string(),
+        })
     }
 }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,4 +1,8 @@
 mod build;
-mod metadata;
+mod manifest;
+pub mod runtime;
 
-pub use crate::{build::*, metadata::*};
+pub use crate::{
+    build::{discover_proc_block_manifests, CompilationMode},
+    manifest::{generate_manifest, Manifest},
+};

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -1,0 +1,93 @@
+use crate::{
+    build::CompiledModule,
+    runtime::{Metadata, Runtime},
+};
+use anyhow::{Context, Error};
+use serde::Serialize;
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{Seek, SeekFrom},
+    path::Path,
+};
+
+pub fn generate_manifest(
+    modules: Vec<CompiledModule>,
+) -> Result<Manifest, Error> {
+    let mut manifest = Manifest::default();
+
+    for module in modules {
+        let CompiledModule { name, mut module } = module;
+        let _span = tracing::info_span!("Extracting metadata", module = %name)
+            .entered();
+
+        let serialized = module.emit_wasm();
+        let metadata = extract_metadata(&serialized).with_context(|| {
+            format!("Unable to extract metadata from \"{}\"", name)
+        })?;
+        tracing::debug!(
+            %metadata.name,
+            %metadata.version,
+            "Extracted metadata for proc-block",
+        );
+
+        let filename = format!("{}.wasm", name);
+        manifest.serialized.insert(filename.clone(), serialized);
+        manifest.metadata.insert(filename, metadata);
+    }
+
+    Ok(manifest)
+}
+
+fn extract_metadata(serialized: &[u8]) -> Result<Metadata, Error> {
+    Runtime::load(serialized)?.metadata()
+}
+
+#[derive(Default)]
+pub struct Manifest {
+    metadata: HashMap<String, Metadata>,
+    serialized: HashMap<String, Vec<u8>>,
+}
+
+impl Manifest {
+    #[tracing::instrument(skip(self))]
+    pub fn write_to_disk(&self, dir: &Path) -> Result<(), Error> {
+        std::fs::create_dir_all(dir).with_context(|| {
+            format!("Unable to create the \"{}\" directory", dir.display())
+        })?;
+
+        for (name, wasm) in &self.serialized {
+            let filename = dir.join(&name);
+            std::fs::write(&filename, wasm).with_context(|| {
+                format!("Unable to save to \"{}\"", filename.display())
+            })?;
+        }
+
+        save_json(dir.join("metadata.json"), &self.metadata)
+            .context("Unable to save the metadata")?;
+
+        let names: Vec<_> = self.metadata.keys().collect();
+        save_json(dir.join("manifest.json"), &names)
+            .context("Unable to save the manifest")?;
+
+        Ok(())
+    }
+}
+
+fn save_json(
+    path: impl AsRef<Path>,
+    value: &impl Serialize,
+) -> Result<(), Error> {
+    let path = path.as_ref();
+
+    let mut f = File::create(path).with_context(|| {
+        format!("Unable to open \"{}\" for writing", path.display())
+    })?;
+
+    serde_json::to_writer_pretty(&mut f, &value)?;
+
+    let len = f.seek(SeekFrom::End(0))?;
+    tracing::debug!(bytes_written = len, path = %path.display(), "Saved");
+
+    Ok(())
+}

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -80,8 +80,7 @@ impl Runtime {
 
         self.rune
             .graph(&mut self.store)
-            .context("Unable to call the graph() function")?
-            .context("Unable to determine the node's inputs and outputs")?;
+            .context("Unable to call the graph() function")??;
 
         let ctx = self.store.data_mut().runtime.graph_ctx.take().unwrap();
         let ctx = ctx.lock().unwrap();


### PR DESCRIPTION
This PR introduces the `cargo xtask metadata`, `cargo xtask graph`, and `cargo xtask kernel` commands.

Running it against the `wit-files` repo's `modulo` example, we get the following:

```console
$ cargo xtask metadata modulo.wasm
{
  "name": "modulo",
  "version": "0.1.0",
  "description": "The modulo proc-block.",
  "arguments": [ ... ],
  "inputs": [
    { "name": "input", ... }
  ],
  "outputs": [
    { "name": "output", ... }
  ]
}

$ cargo xtask graph modulo.wasm modulus=42
{
  "inputs": [
    {
      "name": "input",
      "element-type": "f64",
      "dimensions": { "type": "dynamic" }
    }
  ],
  "outputs": [
    {
      "name": "output",
      "element-type": "f64",
      "dimensions": { "type": "dynamic" }
    }
  ]
}

$ cargo xtask kernel modulo.wasm modulus=42
TODO: show the output
```

I'm particularly happy with how we propagate errors from the proc-block to the host:

```console
$ cargo xtask graph modulo.wasm modulo=42
Error: Unable to infer the input and output tensors

Caused by:
    0: The "modulus" argument was invalid
    1: The argument wasn't provided

$ cargo xtask graph modulo.wasm modulus=3.14 element_type=something-else
Error: Unable to infer the input and output tensors

Caused by:
    0: The "element_type" argument was invalid
    1: Unsupported element type
```