### PR TITLE
Generate markdown docs for proc-blocks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
         rust:
           - nightly
           - stable
-          # MSRV - Required for std::process::Command's get_program() method
-          - 1.57.0
+          # MSRV - Required for using variables with format!() and friends
+          - 1.58.0
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +1418,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1690,7 +1696,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -1949,7 +1955,7 @@ name = "wit-bindgen-gen-rust"
 version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen#e165c0226ad0f00a840ef786079b58d0910dbb6b"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "wit-bindgen-gen-core",
 ]
 
@@ -1958,7 +1964,7 @@ name = "wit-bindgen-gen-rust-wasm"
 version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen#e165c0226ad0f00a840ef786079b58d0910dbb6b"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "wit-bindgen-gen-core",
  "wit-bindgen-gen-rust",
 ]
@@ -1968,7 +1974,7 @@ name = "wit-bindgen-gen-wasmtime"
 version = "0.1.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen#e165c0226ad0f00a840ef786079b58d0910dbb6b"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "wit-bindgen-gen-core",
  "wit-bindgen-gen-rust",
 ]
@@ -2035,6 +2041,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "heck 0.4.0",
+ "itertools",
+ "once_cell",
  "serde",
  "serde_json",
  "structopt",

--- a/argmax/Cargo.toml
+++ b/argmax/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 repository = "https://github.com/hotg-ai/proc-blocks"
 description = "Find the index of the largest element."
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.53"
 cargo_metadata = "0.14.1"
+heck = "0.4.0"
+itertools = "0.10.3"
+once_cell = "1.10.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 structopt = "0.3.26"

--- a/xtask/src/bin/xtask.rs
+++ b/xtask/src/bin/xtask.rs
@@ -1,13 +1,25 @@
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use anyhow::{Context, Error};
+use once_cell::sync::Lazy;
 use structopt::StructOpt;
 use tracing_subscriber::EnvFilter;
 use xtask::{runtime::Runtime, CompilationMode};
 
 fn main() -> Result<(), Error> {
     tracing_subscriber::fmt::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(
+            EnvFilter::from_default_env()
+                .add_directive("cranelift_codegen=warn".parse()?)
+                .add_directive("wasmtime_cranelift=warn".parse()?)
+                .add_directive("regalloc=warn".parse()?),
+        )
         .without_time()
         .init();
 
@@ -18,6 +30,7 @@ fn main() -> Result<(), Error> {
     match cmd {
         Command::Dist(d) => d.execute(),
         Command::Metadata(m) => m.execute(),
+        Command::Doc(d) => d.execute(),
         Command::Graph(g) => g.execute(),
     }
 }
@@ -26,7 +39,11 @@ fn main() -> Result<(), Error> {
 enum Command {
     /// Compile all proc-blocks to WebAssembly and generate a manifest file.
     Dist(Dist),
+    /// Extract the metadata from a proc-block.
     Metadata(Metadata),
+    /// Generate API documentation for one or more proc-blocks.
+    Doc(Doc),
+    /// 
     Graph(Graph),
 }
 
@@ -40,7 +57,7 @@ struct Dist {
     #[structopt(long)]
     debug: bool,
     /// Where to write compiled proc-blocks to.
-    #[structopt(short, long, default_value = ".")]
+    #[structopt(short, long, default_value = &*DIST_DIR)]
     out_dir: PathBuf,
 }
 
@@ -87,13 +104,13 @@ impl Dist {
 struct Metadata {
     /// The WebAssembly module to load.
     #[structopt(parse(from_os_str))]
-    rune: PathBuf,
+    proc_block: PathBuf,
 }
 
 impl Metadata {
     fn execute(self) -> Result<(), Error> {
-        let wasm = std::fs::read(&self.rune).with_context(|| {
-            format!("Unable to read \"{}\"", self.rune.display())
+        let wasm = std::fs::read(&self.proc_block).with_context(|| {
+            format!("Unable to read \"{}\"", self.proc_block.display())
         })?;
 
         let mut runtime = Runtime::load(&wasm)
@@ -157,7 +174,7 @@ impl FromStr for Argument {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (key, value) =
-            s.split_once("=").context("Expected a `key=value` pair")?;
+            s.split_once('=').context("Expected a `key=value` pair")?;
 
         Ok(Argument {
             key: key.to_string(),
@@ -165,3 +182,100 @@ impl FromStr for Argument {
         })
     }
 }
+
+#[derive(Debug, StructOpt)]
+struct Doc {
+    /// Where to write the generated documentation.
+    #[structopt(short, long, default_value = &*DOCS_DIR)]
+    out_dir: PathBuf,
+    /// The WebAssembly modules to document.
+    #[structopt(parse(from_os_str))]
+    proc_blocks: Vec<PathBuf>,
+}
+
+impl Doc {
+    fn execute(self) -> Result<(), Error> {
+        std::fs::create_dir_all(&self.out_dir).with_context(|| {
+            format!(
+                "Unable to create the \"{}\" directory",
+                self.out_dir.display()
+            )
+        })?;
+
+        for proc_block in &self.proc_blocks {
+            let _span = tracing::info_span!("documenting").entered();
+
+            let filename = proc_block
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .context("Unable to get the filename")?;
+
+            tracing::info!(
+                name = filename,
+                path = %proc_block.display(),
+                "Generating Documentation",
+            );
+
+            let wasm = std::fs::read(proc_block).with_context(|| {
+                format!("Unable to read \"{}\"", proc_block.display())
+            })?;
+
+            tracing::debug!(
+                bytes_read = wasm.len(),
+                "Read the module into memory"
+            );
+
+            let mut r = Runtime::load(&wasm)
+                .context("Unable to load the proc-block")?;
+            let meta = r
+                .metadata()
+                .context("Unable to extract the proc-block metadata")?;
+
+            let dest = self.out_dir.join(filename).with_extension("md");
+            tracing::debug!(path = %dest.display(), "Opened file for writing");
+
+            let f = File::create(&dest).with_context(|| {
+                format!("Unable to open \"{}\" for writing", dest.display())
+            })?;
+            let mut writer = BufWriter::new(f);
+
+            xtask::document(&mut writer, &meta)
+                .context("Unable to generate the documentation")?;
+
+            writer.flush().context("Flush failed")?;
+        }
+
+        Ok(())
+    }
+}
+
+static PROJECT_ROOT: Lazy<String> = Lazy::new(|| {
+    for ancestor in Path::new(env!("CARGO_MANIFEST_DIR")).ancestors() {
+        if ancestor.join(".git").exists() {
+            return ancestor.display().to_string();
+        }
+    }
+
+    String::from(".")
+});
+
+static TARGET_DIR: Lazy<String> = Lazy::new(|| {
+    Path::new(PROJECT_ROOT.as_str())
+        .join("target")
+        .display()
+        .to_string()
+});
+
+static DIST_DIR: Lazy<String> = Lazy::new(|| {
+    Path::new(TARGET_DIR.as_str())
+        .join("proc-blocks")
+        .display()
+        .to_string()
+});
+
+static DOCS_DIR: Lazy<String> = Lazy::new(|| {
+    Path::new(TARGET_DIR.as_str())
+        .join("proc-block-docs")
+        .display()
+        .to_string()
+});

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -117,7 +117,7 @@ impl ProcBlocks {
 
         for lib in libs {
             let filename = artifact_dir
-                .join(lib.replace("-", "_"))
+                .join(lib.replace('-', "_"))
                 .with_extension("wasm");
             tracing::debug!(
                 filename = %filename.display(),

--- a/xtask/src/docs.rs
+++ b/xtask/src/docs.rs
@@ -1,0 +1,293 @@
+use std::io::Write;
+
+use anyhow::Error;
+use itertools::Itertools;
+
+use crate::runtime::{
+    runtime_v1::ArgumentType, ArgumentHint, ArgumentMetadata, Dimensions,
+    Metadata, TensorHint, TensorMetadata,
+};
+
+pub fn document(w: &mut dyn Write, meta: &Metadata) -> Result<(), Error> {
+    let _span = tracing::info_span!(
+        "Generating documentation",
+        name = %meta.name,
+    )
+    .entered();
+
+    let Metadata {
+        name,
+        version,
+        description,
+        repository,
+        homepage,
+        tags,
+        arguments,
+        inputs,
+        outputs,
+    } = meta;
+
+    render_title(w, name, version)?;
+    render_repo_and_home(w, repository, homepage)?;
+    render_tags(w, tags)?;
+    render_description(w, description)?;
+    render_arguments(w, arguments)?;
+    render_tensors(w, "Input Tensors", inputs)?;
+    render_tensors(w, "Output Tensors", outputs)?;
+
+    Ok(())
+}
+
+fn render_tensors(
+    w: &mut dyn Write,
+    title: &str,
+    outputs: &[TensorMetadata],
+) -> Result<(), Error> {
+    writeln!(w, "## {title}")?;
+    writeln!(w)?;
+
+    if outputs.is_empty() {
+        writeln!(w, "*(none)*")?;
+        writeln!(w)?;
+    }
+
+    for output in outputs {
+        render_tensor_metadata(w, output)?;
+        writeln!(w)?;
+    }
+
+    Ok(())
+}
+
+fn render_tensor_metadata(
+    w: &mut dyn Write,
+    meta: &TensorMetadata,
+) -> Result<(), Error> {
+    let TensorMetadata {
+        name,
+        description,
+        hints,
+    } = meta;
+
+    writeln!(w, "### The `{name}` Tensor")?;
+    writeln!(w)?;
+
+    if let Some(description) = description {
+        writeln!(w, "{description}")?;
+        writeln!(w)?;
+    }
+
+    render_tensor_hints(w, hints)?;
+
+    Ok(())
+}
+
+fn render_tensor_hints(
+    w: &mut dyn Write,
+    hints: &Vec<TensorHint>,
+) -> Result<(), Error> {
+    if hints.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(w, "Hints:")?;
+
+    for hint in hints {
+        render_tensor_hint(w, hint)?;
+    }
+
+    Ok(())
+}
+
+fn render_tensor_hint(
+    w: &mut dyn Write,
+    hint: &TensorHint,
+) -> Result<(), Error> {
+    match hint {
+        TensorHint::DisplayAs(ty) => {
+            writeln!(w, "- Display as `{ty}`")?;
+        },
+        TensorHint::SupportedShape {
+            accepted_element_types,
+            dimensions,
+        } => {
+            write!(w, "- A ")?;
+
+            match dimensions {
+                Dimensions::Dynamic => {
+                    write!(w, "dynamically sized tensor")?;
+                },
+                Dimensions::Fixed(fixed) => {
+                    let dims = fixed.iter().join("`, `");
+                    writeln!(
+                        w,
+                        "fixed-size tensor with dimensions [`{dims}`]"
+                    )?;
+                },
+            }
+
+            let elements = accepted_element_types.iter().join("`, `");
+
+            writeln!(w, " which may contain one of `{elements}`")?;
+        },
+    }
+
+    Ok(())
+}
+
+fn render_arguments(
+    w: &mut dyn Write,
+    arguments: &[ArgumentMetadata],
+) -> Result<(), Error> {
+    writeln!(w, "## Arguments")?;
+    writeln!(w)?;
+
+    if arguments.is_empty() {
+        writeln!(w, "*(none)*")?;
+        writeln!(w)?;
+    }
+
+    for arg in arguments {
+        render_argument(w, arg)?;
+    }
+
+    Ok(())
+}
+
+fn render_argument(
+    w: &mut dyn Write,
+    arg: &ArgumentMetadata,
+) -> Result<(), Error> {
+    let ArgumentMetadata {
+        name,
+        description,
+        default_value,
+        hints,
+    } = arg;
+
+    writeln!(w, "### The `{name}` Argument")?;
+    writeln!(w)?;
+
+    if let Some(default) = default_value {
+        writeln!(w, "(Default: `{default}`)")?;
+        writeln!(w)?;
+    }
+
+    if let Some(description) = description {
+        writeln!(w, "{description}")?;
+        writeln!(w)?;
+    }
+
+    render_argument_hints(w, hints)?;
+
+    Ok(())
+}
+
+fn render_argument_hints(
+    w: &mut dyn Write,
+    hints: &[ArgumentHint],
+) -> Result<(), Error> {
+    if hints.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(w, "Hints:")?;
+
+    for hint in hints {
+        match hint {
+            ArgumentHint::NonNegativeNumber => write!(w, "- Non-negative")?,
+            ArgumentHint::StringEnum(variants) => {
+                let variants = variants.join("`, `");
+                writeln!(w, "- One of [`\"{variants}\"`]")?;
+            },
+            ArgumentHint::NumberInRange { max, min } => {
+                writeln!(w, "- A value between `{min}` and `{max}`")?
+            },
+            ArgumentHint::SupportedArgumentType(ArgumentType::Float) => {
+                writeln!(w, "- A float")?
+            },
+            ArgumentHint::SupportedArgumentType(ArgumentType::Integer) => {
+                writeln!(w, "- An integer")?
+            },
+            ArgumentHint::SupportedArgumentType(
+                ArgumentType::UnsignedInteger,
+            ) => writeln!(w, "- An unsigned integer")?,
+            ArgumentHint::SupportedArgumentType(ArgumentType::String) => {
+                writeln!(w, "- A string")?
+            },
+            ArgumentHint::SupportedArgumentType(ArgumentType::LongString) => {
+                writeln!(w, "- A multi-line string")?
+            },
+        }
+    }
+
+    Ok(())
+}
+
+fn render_description(
+    w: &mut dyn Write,
+    description: &Option<String>,
+) -> Result<(), Error> {
+    if let Some(description) = description {
+        writeln!(w, "{description}")?;
+        writeln!(w)?;
+    }
+
+    Ok(())
+}
+
+fn render_title(
+    w: &mut dyn Write,
+    name: &str,
+    version: &str,
+) -> Result<(), Error> {
+    writeln!(w, "# {name} {version}")?;
+    writeln!(w)?;
+
+    Ok(())
+}
+
+fn render_repo_and_home(
+    w: &mut dyn Write,
+    repository: &Option<String>,
+    homepage: &Option<String>,
+) -> Result<(), Error> {
+    match (non_empty(repository), non_empty(homepage)) {
+        (None, Some(home)) => {
+            writeln!(w, "(*[Homepage]({home})*)")?;
+            writeln!(w)?;
+        },
+        (Some(repo), None) => {
+            writeln!(w, "(*[Repository]({repo})*)")?;
+            writeln!(w)?;
+        },
+        (Some(repo), Some(home)) => {
+            writeln!(w, "(*[Repository]({repo})|[Homepage]({home})*)")?;
+            writeln!(w)?;
+        },
+        (None, None) => {},
+    }
+
+    Ok(())
+}
+
+fn render_tags(w: &mut dyn Write, tags: &[String]) -> Result<(), Error> {
+    if !tags.is_empty() {
+        writeln!(w, "Tags:")?;
+
+        for tag in tags {
+            writeln!(w, "- `{}`", tag)?;
+        }
+
+        writeln!(w)?;
+    }
+
+    Ok(())
+}
+
+fn non_empty(value: &Option<impl AsRef<str>>) -> Option<&str> {
+    match value.as_ref().map(|v| v.as_ref()) {
+        Some(v) if !v.is_empty() => Some(v),
+        _ => None,
+    }
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,8 +1,10 @@
 mod build;
+mod docs;
 mod manifest;
 pub mod runtime;
 
 pub use crate::{
     build::{discover_proc_block_manifests, CompilationMode},
+    docs::document,
     manifest::{generate_manifest, Manifest},
 };

--- a/xtask/src/runtime.rs
+++ b/xtask/src/runtime.rs
@@ -161,6 +161,24 @@ pub enum ElementType {
     Utf8,
 }
 
+impl Display for ElementType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ElementType::U8 => write!(f, "u8"),
+            ElementType::I8 => write!(f, "i8"),
+            ElementType::U16 => write!(f, "u16"),
+            ElementType::I16 => write!(f, "i16"),
+            ElementType::U32 => write!(f, "u32"),
+            ElementType::I32 => write!(f, "i32"),
+            ElementType::F32 => write!(f, "f32"),
+            ElementType::U64 => write!(f, "u64"),
+            ElementType::I64 => write!(f, "i64"),
+            ElementType::F64 => write!(f, "f64"),
+            ElementType::Utf8 => write!(f, "utf-8"),
+        }
+    }
+}
+
 impl From<runtime_v1::ElementType> for ElementType {
     fn from(e: runtime_v1::ElementType) -> Self {
         match e {
@@ -191,6 +209,15 @@ pub enum Dimensions {
 pub enum Dimension {
     Fixed(NonZeroUsize),
     Dynamic,
+}
+
+impl Display for Dimension {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Dimension::Fixed(fixed) => fixed.fmt(f),
+            Dimension::Dynamic => "*".fmt(f),
+        }
+    }
 }
 
 impl From<runtime_v1::Dimensions<'_>> for Dimensions {


### PR DESCRIPTION
This adds a `cargo xtask doc` command which generates documentation for one or more compiled proc-blocks.

This is what you get when you run `cargo xtask doc target/wasm32-unknown-unknown/release/argmax.wasm`.

![2022-04-06_18-18-50-26](https://user-images.githubusercontent.com/17380079/161958986-874c2e33-09e6-4248-97c5-1893961202c8.png)
