### PR TITLE
Revert "added support for 3-d tensor in argmax"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,8 +62,7 @@ dependencies = [
 name = "argmax"
 version = "0.11.3"
 dependencies = [
- "hotg-rune-proc-blocks 0.11.3",
- "ndarray",
+ "hotg-rune-proc-blocks 0.1.0",
  "wit-bindgen-rust",
 ]
 

--- a/argmax/Cargo.toml
+++ b/argmax/Cargo.toml
@@ -4,14 +4,13 @@ version = "0.11.3"
 edition = "2018"
 publish = false
 repository = "https://github.com/hotg-ai/proc-blocks"
+description = "Find the index of the largest element."
+
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hotg-rune-proc-blocks = "^0.11.0"
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", optional = true }
-ndarray = "0.15.4"
-
-[features]
-default = []
-metadata = ["wit-bindgen-rust"]
+hotg-rune-proc-blocks = { path = "../support" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }

--- a/argmax/src/lib.rs
+++ b/argmax/src/lib.rs
@@ -1,136 +1,148 @@
-#![cfg_attr(not(feature = "metadata"), no_std)]
-#[macro_use]
-extern crate alloc;
+use crate::{
+    proc_block_v1::{BadInputReason, GraphError, InvalidInput, KernelError},
+    runtime_v1::*,
+};
+use hotg_rune_proc_blocks::BufferExt;
+use std::cmp::Ordering;
 
-use alloc::{sync::Arc, vec::Vec};
-use hotg_rune_proc_blocks::{ProcBlock, Tensor, Transform};
-// use core::sync::Arc;
+wit_bindgen_rust::import!("../wit-files/rune/runtime-v1.wit");
+wit_bindgen_rust::export!("../wit-files/rune/proc-block-v1.wit");
 
-#[derive(Debug, Clone, PartialEq, ProcBlock)]
-pub struct Argmax {}
+struct ProcBlockV1;
 
-impl Argmax {
-    pub const fn new() -> Self {
-        Argmax {}
+impl proc_block_v1::ProcBlockV1 for ProcBlockV1 {
+    fn register_metadata() {
+        let metadata = Metadata::new("Arg Max", env!("CARGO_PKG_VERSION"));
+        metadata.set_description(env!("CARGO_PKG_DESCRIPTION"));
+        metadata.set_repository(env!("CARGO_PKG_REPOSITORY"));
+        metadata.set_homepage(env!("CARGO_PKG_HOMEPAGE"));
+        metadata.add_tag("max");
+        metadata.add_tag("index");
+        metadata.add_tag("numeric");
+
+        let input = TensorMetadata::new("input");
+        let hint =
+            supported_shapes(&[ElementType::F32], Dimensions::Fixed(&[0]));
+        input.add_hint(&hint);
+        metadata.add_input(&input);
+
+        let max = TensorMetadata::new("max_index");
+        max.set_description("The index of the element with the highest value");
+        let hint =
+            supported_shapes(&[ElementType::U32], Dimensions::Fixed(&[1]));
+        max.add_hint(&hint);
+        metadata.add_output(&max);
+
+        register_node(&metadata);
+    }
+
+    fn graph(id: String) -> Result<(), GraphError> {
+        let ctx = GraphContext::for_node(&id).ok_or_else(|| {
+            GraphError::Other("Unable to get the graph context".to_string())
+        })?;
+
+        ctx.add_input_tensor(
+            "input",
+            ElementType::F32,
+            Dimensions::Fixed(&[0]),
+        );
+        ctx.add_output_tensor(
+            "max_index",
+            ElementType::U32,
+            Dimensions::Fixed(&[1]),
+        );
+
+        Ok(())
+    }
+
+    fn kernel(id: String) -> Result<(), KernelError> {
+        let ctx = KernelContext::for_node(&id).ok_or_else(|| {
+            KernelError::Other("Unable to get the kernel context".to_string())
+        })?;
+
+        let TensorResult {
+            element_type,
+            dimensions,
+            buffer,
+        } = ctx.get_input_tensor("input").ok_or_else(|| {
+            KernelError::InvalidInput(InvalidInput {
+                name: "input".to_string(),
+                reason: BadInputReason::NotFound,
+            })
+        })?;
+
+        let index = match element_type {
+            ElementType::U8 => arg_max(buffer.elements::<u8>()),
+            ElementType::I8 => arg_max(buffer.elements::<i8>()),
+            ElementType::U16 => arg_max(buffer.elements::<u16>()),
+            ElementType::I16 => arg_max(buffer.elements::<i16>()),
+            ElementType::U32 => arg_max(buffer.elements::<u32>()),
+            ElementType::I32 => arg_max(buffer.elements::<i32>()),
+            ElementType::F32 => arg_max(buffer.elements::<f32>()),
+            ElementType::U64 => arg_max(buffer.elements::<u64>()),
+            ElementType::I64 => arg_max(buffer.elements::<i64>()),
+            ElementType::F64 => arg_max(buffer.elements::<f64>()),
+            other => {
+                return Err(KernelError::Other(format!(
+                "The Arg Max proc-block only accepts f32 tensors, found {:?}",
+                other,
+                )))
+            },
+        };
+
+        let index = match index {
+            Some(ix) => ix,
+            None => {
+                return Err(KernelError::Other(
+                    "The input tensor was empty".to_string(),
+                ))
+            },
+        };
+        let resulting_tensor = (index as u32).to_le_bytes();
+
+        ctx.set_output_tensor(
+            "max_index",
+            TensorParam {
+                element_type,
+                dimensions: &dimensions,
+                buffer: &resulting_tensor,
+            },
+        );
+
+        Ok(())
     }
 }
 
-impl Default for Argmax {
-    fn default() -> Self {
-        Argmax::new()
-    }
-}
+fn arg_max<T>(values: &[T]) -> Option<usize>
+where
+    T: PartialOrd,
+{
+    let (index, _) = values
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(Ordering::Less))?;
 
-impl Transform<Tensor<f32>> for Argmax {
-    type Output = Tensor<u32>;
-
-    fn transform(&mut self, input: Tensor<f32>) -> Tensor<u32> {
-        let dim = input.dimensions(); //[1, 26, 37]
-        let input = input.elements();
-        let len = dim.len();
-
-        if len == 1 {
-            let (index, _) =
-                input.iter().enumerate().fold((0, 0.0), |max, (ind, &val)| {
-                    if val > max.1 {
-                        (ind, val)
-                    } else {
-                        max
-                    }
-                });
-
-            let v: Vec<u32> = vec![index as u32];
-
-            return Tensor::new_vector(v);
-        } else {
-            let mut vec_1d: Vec<u32> = Vec::new();
-            let j = dim[2];
-
-            for i in 0..dim[1] {
-                let (ind, _) =
-                    input[i * j..(i + 1) * j].iter().enumerate().fold(
-                        (0, 0.0),
-                        |max, (ind, &val)| {
-                            if val > max.1 {
-                                (ind, val)
-                            } else {
-                                max
-                            }
-                        },
-                    );
-                vec_1d.push(ind as u32);
-            }
-            let elements: Arc<[u32]> = vec_1d.into();
-            Tensor::new_row_major(elements, vec![1, dim[1]])
-        }
-    }
-}
-
-#[cfg(feature = "metadata")]
-pub mod metadata {
-    wit_bindgen_rust::import!("../wit-files/rune/runtime-v1.wit");
-    wit_bindgen_rust::export!("../wit-files/rune/rune-v1.wit");
-
-    struct RuneV1;
-
-    impl rune_v1::RuneV1 for RuneV1 {
-        fn start() {
-            use runtime_v1::*;
-
-            let metadata = Metadata::new("Arg Max", env!("CARGO_PKG_VERSION"));
-            metadata.set_description("Find the index of the largest element.");
-            metadata.set_repository(env!("CARGO_PKG_REPOSITORY"));
-            metadata.set_homepage(env!("CARGO_PKG_HOMEPAGE"));
-            metadata.add_tag("max");
-            metadata.add_tag("index");
-            metadata.add_tag("numeric");
-
-            let input = TensorMetadata::new("input");
-            let hint = supported_shapes(
-                &[ElementType::Float32],
-                Dimensions::Fixed(&[0]),
-            );
-            input.add_hint(&hint);
-            metadata.add_input(&input);
-
-            let max = TensorMetadata::new("max_index");
-            max.set_description(
-                "The index of the element with the highest value",
-            );
-            let hint = supported_shapes(
-                &[ElementType::Uint32],
-                Dimensions::Fixed(&[1]),
-            );
-            max.add_hint(&hint);
-            metadata.add_output(&max);
-
-            register_node(&metadata);
-        }
-    }
+    Some(index)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[test]
     fn test_argmax() {
-        let v = Tensor::new_vector(vec![2.3, 12.4, 55.1, 15.4]);
-        let mut argmax = Argmax::default();
-        let output = argmax.transform(v);
-        let should_be: Tensor<u32> = [2].into();
-        assert_eq!(output, should_be);
+        let values = [2.3, 12.4, 55.1, 15.4];
+
+        let max = arg_max(&values).unwrap();
+
+        assert_eq!(max, 2);
     }
+
     #[test]
-    fn test_multi_dimension() {
-        let v = [[
-            [1.0, 2.0, 3.0, 4.0],
-            [1.0, 2.0, 3.0, 4.0],
-            [1.0, 2.0, 3.0, 4.0],
-        ]]
-        .into();
-        let mut argmax = Argmax::default();
-        let output = argmax.transform(v);
-        let should_be: Tensor<u32> = [[3, 3, 3]].into();
-        assert_eq!(output, should_be);
+    fn empty_inputs_are_an_error() {
+        let empty: &[f32] = &[];
+        let result = arg_max(empty);
+
+        assert!(result.is_none());
     }
 }


### PR DESCRIPTION
As mentioned in https://github.com/hotg-ai/proc-blocks/pull/56#issuecomment-1099673712, we shouldn't have merged 3D support for `argmax` into `master` when it is written for the old ABI.

Reverts hotg-ai/proc-blocks#56